### PR TITLE
Fix: Correct undefined crawler reference in AppStack output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build-and-type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and type check
+        run: npm run build


### PR DESCRIPTION
Moves the definition of the Glue S3 crawler and its role to occur before its reference in a CfnOutput, resolving a TypeError during CDK synthesis.

Feat: Add CI workflow for type checking

Introduces a GitHub Actions workflow that triggers on push and pull_request events. The workflow installs Node.js, installs dependencies using npm ci, and runs `npm run build` to perform TypeScript type checking, helping to catch errors early.